### PR TITLE
changed purecss-type variable to purecss_type in generator function

### DIFF
--- a/lib/purecss/generators/install_generator.rb
+++ b/lib/purecss/generators/install_generator.rb
@@ -8,15 +8,15 @@ module Purecss
       
       def add_assets
         if stylesheets_type=='nonresponsive'
-          purecss-type = 'pure-nr-min'
+          purecss_type = 'pure-nr-min'
         elsif stylesheets_type=='responsive'
-          purecss-type = 'pure-min'
+          purecss_type = 'pure-min'
         else
           raise "'#{stylesheets_type}'' is not recognized, use either 'responsive' or 'nonresponsive'"
           
         end
 
-        insert_into_file "app/assets/stylesheets/application#{detect_css_format[0]}", "#{detect_css_format[1]} require #{purecss-type}\n", :after => "require_self\n"              
+        insert_into_file "app/assets/stylesheets/application#{detect_css_format[0]}", "#{detect_css_format[1]} require #{purecss_type}\n", :after => "require_self\n"              
       end
       
       def detect_css_format


### PR DESCRIPTION
Hi,
  The generator fails because "purecss-type" is not a valid variable name. The interpreter tries to
  send a message to the "-" method in an undefined variable named purecss.

  I renamed the variable and now it's working fine.

Cheers!
Sebastian.
